### PR TITLE
advanced lock

### DIFF
--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/config/Locker.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/config/Locker.kt
@@ -1,0 +1,65 @@
+package com.fastcampus.webfluxcoroutine.config
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.reactor.awaitSingle
+import mu.KotlinLogging
+import org.springframework.cache.interceptor.SimpleKey
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class Locker(
+    redisTemplate: ReactiveRedisTemplate<Any, Any>,
+) {
+
+    private val localLock = ConcurrentHashMap<SimpleKey, Boolean>()
+
+    private val ops = redisTemplate.opsForValue()
+
+    suspend fun <T> lock(key: SimpleKey, work: suspend () -> T): T {
+        if (!tryLock(key)) throw TimeoutException("fail to obtain lock ($key)")
+        try {
+            return work.invoke()
+        } finally {
+            unLock(key)
+        }
+    }
+
+    // spin lock
+    // 몇초 기다렸다가 다시 요청
+    private suspend fun tryLock(key: SimpleKey): Boolean {
+        val start = System.nanoTime()
+
+        // redisson
+        // ops.tryLock() // pubsub 기반
+        while (
+            !localLock.contains(key) &&
+            !ops.setIfAbsent(key, true, 10.seconds.toJavaDuration()).awaitSingle()
+        ) {
+            logger.debug { "- spring lock : $key" }
+            delay(100)
+            val elapsed = (System.nanoTime() - start).nanoseconds
+            if (elapsed >= 10.seconds) return false
+        }
+
+        localLock[key] = true
+        return true
+    }
+
+    private suspend fun unLock(key: SimpleKey) {
+        try {
+            ops.delete(key).awaitSingle()
+        } catch (e: Exception) {
+            logger.warn(e.message, e)
+        } finally {
+            localLock.remove(key)
+        }
+    }
+}

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/controller/account/AccountController.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/controller/account/AccountController.kt
@@ -1,0 +1,35 @@
+package com.fastcampus.webfluxcoroutine.controller.account
+
+import com.fastcampus.webfluxcoroutine.controller.account.dto.AccountResponseDto
+import com.fastcampus.webfluxcoroutine.service.AccountService
+import mu.KotlinLogging
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger { }
+
+@RestController
+@RequestMapping("/account")
+class AccountController(
+    private val accountService: AccountService,
+) {
+
+    @GetMapping("/{id}")
+    suspend fun get(
+        @PathVariable id: Long,
+    ): AccountResponseDto {
+        return accountService.get(id)
+    }
+
+    @PutMapping("/{id}/{amount}")
+    suspend fun deposit(
+        @PathVariable id: Long,
+        @PathVariable amount: Long,
+    ): AccountResponseDto {
+        accountService.deposit(id, amount)
+        return accountService.get(id)
+    }
+}

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/controller/account/AccountController.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/controller/account/AccountController.kt
@@ -32,4 +32,13 @@ class AccountController(
         accountService.deposit(id, amount)
         return accountService.get(id)
     }
+
+    @PutMapping("/redis/{id}/{amount}")
+    suspend fun depositForRedis(
+        @PathVariable id: Long,
+        @PathVariable amount: Long,
+    ): AccountResponseDto {
+        accountService.depositForRedis(id, amount)
+        return accountService.get(id)
+    }
 }

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/controller/account/dto/AccountResponseDto.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/controller/account/dto/AccountResponseDto.kt
@@ -1,0 +1,15 @@
+package com.fastcampus.webfluxcoroutine.controller.account.dto
+
+import com.fastcampus.webfluxcoroutine.model.Article
+
+data class AccountResponseDto(
+    val id: Long,
+    val balance: Long,
+)
+
+fun Article.toAccountResponseDto(): AccountResponseDto {
+    return AccountResponseDto(
+        id = this.id,
+        balance = this.balance,
+    )
+}

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/model/Article.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/model/Article.kt
@@ -3,6 +3,7 @@ package com.fastcampus.webfluxcoroutine.model
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.annotation.Version
 import org.springframework.data.relational.core.mapping.Table
 import java.io.Serializable
 import java.time.LocalDateTime
@@ -18,6 +19,11 @@ data class Article(
     var body: String? = null,
 
     var authorId: Long? = null,
+
+    var balance: Long = 0,
+
+    @Version
+    var version: Int = 1,
 
     @CreatedDate
     var createdAt: LocalDateTime? = null,

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/repository/ArticleRepository.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/repository/ArticleRepository.kt
@@ -2,6 +2,8 @@ package com.fastcampus.webfluxcoroutine.repository
 
 import com.fastcampus.webfluxcoroutine.model.Article
 import kotlinx.coroutines.flow.Flow
+import org.springframework.data.relational.core.sql.LockMode
+import org.springframework.data.relational.repository.Lock
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 
@@ -9,4 +11,7 @@ import org.springframework.stereotype.Repository
 interface ArticleRepository: CoroutineCrudRepository<Article, Long> {
 
     suspend fun findAllByTitleContains(title: String): Flow<Article>
+
+    @Lock(LockMode.PESSIMISTIC_WRITE)
+    suspend fun findArticleById(id: Long): Article?
 }

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/service/AccountService.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/service/AccountService.kt
@@ -22,7 +22,7 @@ class AccountService(
         id: Long,
         amount: Long
     ) {
-        accountRepository.findById(id)?.let { account ->
+        accountRepository.findArticleById(id)?.let { account ->
             delay(3000)
             account.balance += amount
             accountRepository.save(account)

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/service/AccountService.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/service/AccountService.kt
@@ -1,9 +1,11 @@
 package com.fastcampus.webfluxcoroutine.service
 
+import com.fastcampus.webfluxcoroutine.config.Locker
 import com.fastcampus.webfluxcoroutine.controller.account.dto.AccountResponseDto
 import com.fastcampus.webfluxcoroutine.controller.account.dto.toAccountResponseDto
 import com.fastcampus.webfluxcoroutine.exception.NotFoundException
 import kotlinx.coroutines.delay
+import org.springframework.cache.interceptor.SimpleKey
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import com.fastcampus.webfluxcoroutine.repository.ArticleRepository as AccountRepository
@@ -11,6 +13,7 @@ import com.fastcampus.webfluxcoroutine.repository.ArticleRepository as AccountRe
 @Service
 class AccountService(
     private val accountRepository: AccountRepository,
+    private val locker: Locker,
 ) {
 
     suspend fun get(id: Long): AccountResponseDto {
@@ -29,4 +32,18 @@ class AccountService(
         } ?: throw NotFoundException("id: $id")
     }
 
+    @Transactional
+    suspend fun depositForRedis(
+        id: Long,
+        amount: Long
+    ) {
+        val key = SimpleKey(AccountService::deposit.name, id)
+        return locker.lock(key) {
+            accountRepository.findById(id)?.let { account ->
+                delay(3000)
+                account.balance += amount
+                accountRepository.save(account)
+            } ?: throw NotFoundException("id: $id")
+        }
+    }
 }

--- a/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/service/AccountService.kt
+++ b/webflux-coroutine-advanced/src/main/kotlin/com/fastcampus/webfluxcoroutine/service/AccountService.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.webfluxcoroutine.service
+
+import com.fastcampus.webfluxcoroutine.controller.account.dto.AccountResponseDto
+import com.fastcampus.webfluxcoroutine.controller.account.dto.toAccountResponseDto
+import com.fastcampus.webfluxcoroutine.exception.NotFoundException
+import kotlinx.coroutines.delay
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import com.fastcampus.webfluxcoroutine.repository.ArticleRepository as AccountRepository
+
+@Service
+class AccountService(
+    private val accountRepository: AccountRepository,
+) {
+
+    suspend fun get(id: Long): AccountResponseDto {
+        return accountRepository.findById(id)?.toAccountResponseDto() ?: throw NotFoundException("id: $id")
+    }
+
+    @Transactional
+    suspend fun deposit(
+        id: Long,
+        amount: Long
+    ) {
+        accountRepository.findById(id)?.let { account ->
+            delay(3000)
+            account.balance += amount
+            accountRepository.save(account)
+        } ?: throw NotFoundException("id: $id")
+    }
+
+}

--- a/webflux-coroutine-advanced/src/main/resources/db-init/schema.sql
+++ b/webflux-coroutine-advanced/src/main/resources/db-init/schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS TB_ARTICLE (
     title VARCHAR(255),
     body VARCHAR(2000),
     author_id BIGINT,
+    balance BIGINT,
+    version INT,
     created_at TIMESTAMP,
     updated_at TIMESTAMP
 );


### PR DESCRIPTION
### Optimistic Lock
- version 필드 + `@Version` annotation 사용
- 논리 정합성을 유지하는 간단한 구현 방법
    - 오류가 발생함
    - 오류가 발생해도 되는 서비스일 경우 사용


### Pessimistic Lock
- `@lock(LockMode.PESSIMISTIC_WRITE)` Annotation 사용
- Row Lock 이용해서 동시 요청 시에도 정합성 보장됨
- Lock 이 풀려야 다음 요청에서 해당 Row Read 가능
- Lock 을 main DB 가 data lock을 관리 해서 부하가 DB에서 발생하는 단점


### Distributed Lock
- 다른말로 Application Lock
- 실습은 spin lock
    - 몇초 기다린다음 다시 lock 요청
- 추천은 redisson의 `ops.tryLock()`
    - pubsub 기반

